### PR TITLE
Få mulitselect til å funke

### DIFF
--- a/Messages/app/src/main/java/no/bekk/android/messages/MessagesActivity.java
+++ b/Messages/app/src/main/java/no/bekk/android/messages/MessagesActivity.java
@@ -45,7 +45,8 @@ public class MessagesActivity extends Activity {
 
         final MessagesAdapter msgAdapter = new MessagesAdapter(this, messages);
         lvMessages.setAdapter(msgAdapter);
-
+        
+        lvMessages.setChoiceMode(ListView.CHOICE_MODE_MULTIPLE_MODAL);
         lvMessages.setMultiChoiceModeListener(new AbsListView.MultiChoiceModeListener() {
             private int selectedCount;
             @Override


### PR DESCRIPTION
Jeg prøvde meg uten denne linjen og da funker ikke select funksjonen, ihvertfall ikke på 4.2.2.
Prøver man uten linjen så longklikker man bare uten at noe skjer.
Det funker nok hos dere men ikke hos meg.
